### PR TITLE
Add clean gitignore for Vite/Tailwind setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# Node dependencies
+node_modules/
+
+# Vite build output
+dist/
+dist-ssr/
+.vite/
+
 # Logs
 logs
 *.log
@@ -7,18 +15,30 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-node_modules
-dist
-dist-ssr
+# Testing
+coverage/
+.nyc_output/
+
+# Local environment variables
+.env
+.env.*.local
 *.local
+
+# Miscellaneous
+.DS_Store
+Thumbs.db
 
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
-.idea
-.DS_Store
+.idea/
 *.suo
 *.ntvs*
 *.njsproj
 *.sln
 *.sw?
+
+# Temporary files
+tmp/
+temp/
+.cache/


### PR DESCRIPTION
## Summary
- rebuild `.gitignore` for Vite/Tailwind projects

## Testing
- `npm run lint` *(fails: cannot find module `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_687085c2d0a0832395b1aec46f606078