### PR TITLE
Fix missing Disc export runtime error

### DIFF
--- a/src/src/components/Game/DiscThrowingGame.tsx
+++ b/src/src/components/Game/DiscThrowingGame.tsx
@@ -5,7 +5,7 @@ import GameUI from "./GameUI";
 import { Joystick } from "../Joystick";
 import { useGame } from "../../lib/stores/useGame";
 import { useAudio } from "../../lib/stores/useAudio";
-import { GameObject, Target, Obstacle } from "../../lib/gameTypes";
+import type { GameObject, Target, Obstacle } from "../../lib/gameTypes";
 import { generateSingleTarget, generateObstacles } from "../../lib/gameUtils";
 
 const DiscThrowingGame: React.FC = () => {

--- a/src/src/components/Game/GameCanvas.tsx
+++ b/src/src/components/Game/GameCanvas.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useCallback, useState } from "react";
 import { useGamePhysics } from "../../hooks/useGamePhysics";
-import { Target, Obstacle, Disc, Vector2D, Vector3D } from "../../lib/gameTypes";
+import type { Target, Obstacle, Disc, Vector2D, Vector3D } from "../../lib/gameTypes";
 import { normalize } from "../../lib/physics";
 
 interface GameCanvasProps {

--- a/src/src/hooks/useGameInput.tsx
+++ b/src/src/hooks/useGameInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { Vector2D } from "../lib/gameTypes";
+import type { Vector2D } from "../lib/gameTypes";
 
 export const useGameInput = () => {
   const [mousePosition, setMousePosition] = useState<Vector2D>({ x: 0, y: 0 });

--- a/src/src/hooks/useGamePhysics.tsx
+++ b/src/src/hooks/useGamePhysics.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { Disc, Target, Obstacle, Vector2D } from '../lib/gameTypes';
+import type { Disc, Target, Obstacle, Vector2D } from '../lib/gameTypes';
 import { 
   PhysicsDisc, 
   Vector2, 

--- a/src/src/lib/gameUtils.ts
+++ b/src/src/lib/gameUtils.ts
@@ -1,4 +1,4 @@
-import { Target, Obstacle } from "./gameTypes";
+import type { Target, Obstacle } from "./gameTypes";
 
 export const generateTargets = (count: number): Target[] => {
   const targets: Target[] = [];


### PR DESCRIPTION
## Summary
- use type-only imports for `Disc` and other game types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68709163137c83239c8352d1cfa34bff