### PR TITLE
Fix runtime import of type-only PhysicsDisc

### DIFF
--- a/src/src/hooks/useGamePhysics.tsx
+++ b/src/src/hooks/useGamePhysics.tsx
@@ -1,14 +1,14 @@
 import { useCallback } from 'react';
 import type { Disc, Target, Obstacle, Vector2D } from '../lib/gameTypes';
-import { 
-  PhysicsDisc, 
-  Vector2, 
-  updateDisc, 
-  checkCollision, 
-  checkTargetHit, 
+import {
+  type PhysicsDisc,
+  type Vector2,
+  updateDisc,
+  checkCollision,
+  checkTargetHit,
   predictTrajectory,
   initializeVelocity,
-  normalize
+  normalize,
 } from '../lib/physics';
 
 export const useGamePhysics = () => {


### PR DESCRIPTION
## Summary
- mark `PhysicsDisc` and `Vector2` imports as types in `useGamePhysics.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: several missing module type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68709361884883239c4becf178cf329b