### PR TITLE
Fix joystick event handling

### DIFF
--- a/src/src/components/Joystick.tsx
+++ b/src/src/components/Joystick.tsx
@@ -32,6 +32,8 @@ export const Joystick: React.FC<JoystickProps> = ({ onTiltChange }) => {
 
   const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     e.preventDefault();
+    // ensure we keep receiving move events even when leaving the element
+    e.currentTarget.setPointerCapture(e.pointerId);
     setDragging(true);
     const tilt = calculateTilt(e.clientX, e.clientY);
     if (tilt) {
@@ -48,8 +50,12 @@ export const Joystick: React.FC<JoystickProps> = ({ onTiltChange }) => {
     }
   };
 
-  const handlePointerUp = () => {
+  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    // release capture so future interactions behave normally
+    e.currentTarget.releasePointerCapture(e.pointerId);
     setDragging(false);
+    // reset tilt when the joystick is released
+    onTiltChange(0, 0);
   };
 
   return (


### PR DESCRIPTION
## Summary
- keep pointer events captured on joystick
- reset tilt when releasing pointer

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6870985abe148323b20d9150c345d477